### PR TITLE
fix: stabilize Telegram GPT-5.2 reasoning replay, add facilitator skill, enable web search via openrouter/perplexity, and restrict certain functions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
 
+# Optional for OpenClaw web_search (Brave provider).
+BRAVE_API_KEY=
+
 # Telegram multi-account bot tokens used by instances/core-human/config/instance.overrides.json5
 TELEGRAM_BOT_TOKEN_VBARSEGYAN=
 TELEGRAM_BOT_TOKEN_DRICHARDSON=

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Set required values in `.env`:
 ```dotenv
 OPENCLAW_GATEWAY_TOKEN=<strong-random-token>
 OPENAI_API_KEY=<provider-key>
+BRAVE_API_KEY=<brave-search-api-key>
 TELEGRAM_BOT_TOKEN_VBARSEGYAN=<telegram-bot-token>
 TELEGRAM_BOT_TOKEN_DRICHARDSON=<telegram-bot-token>
 ```
@@ -137,6 +138,12 @@ oco compose up --instance core-human
 - TOOLS template workflow: `docs/TOOLS_TEMPLATES.md`
 - Product requirements: `docs/REQUIREMENTS.md`
 
+## Skills
+- Repo skills live under `skills/<skill-name>/`.
+- Each skill should include `SKILL.md`; optional UI metadata belongs in `agents/openai.yaml`.
+- Included skill: `skills/thoughtful-oco-facilitator/`
+- Invocation pattern: reference `$thoughtful-oco-facilitator` in the request.
+
 ## Open Source Safety
 - Keep real secrets only in local `.env` (ignored by default).
 - Do not commit runtime state or rendered configs from `instances/*/state` and `instances/*/config/openclaw.json5*`.
@@ -148,10 +155,13 @@ rg -n "sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{20,}|BEGIN (RSA|EC|OPENSSH|PGP|DSA)? 
 ```
 
 ## TODO
+- [ ] Ability to browse the web
 - [ ] Dashboard UI
 - [ ] Kubernetes deployments
 - [ ] SSO OAuth support
 - [ ] Model provider usage and analytics integration
+- [ ] Email integration
+- [ ] Add architecture diagram
 
 ## License
 MIT (`LICENSE`)

--- a/docs/CONFIGURATION_DETAILS.md
+++ b/docs/CONFIGURATION_DETAILS.md
@@ -29,6 +29,14 @@ For each instance, `oco` resolves config in this order:
 
 Later layers override earlier ones.
 
+Safety default in the shared template:
+- `agents.defaults.contextPruning.mode` is set to `off` to keep OpenAI Responses reasoning/tool chains intact during replay.
+- If you re-enable pruning, validate multi-turn tool conversations first (especially on GPT-5 class models).
+
+One-time recovery for already-broken sessions:
+- If a session is already failing with `Item 'rs_...' ... required following item`, start a fresh session id for that conversation.
+- In self-hosted state, remove the stale `sessionId` mapping from `instances/<id>/state/agents/<agent>/sessions/sessions.json` so the next inbound message creates a new session.
+
 ## 3. Inventory Structure
 
 ## 3.1 Top-level
@@ -106,6 +114,7 @@ Common variables:
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `OPENROUTER_API_KEY`
+- `BRAVE_API_KEY` (for `web_search`)
 - channel-specific vars such as `TELEGRAM_BOT_TOKEN_*`
 - CLI path overrides such as `OCO_INVENTORY_PATH`, `OCO_SOUL_TEMPLATES_DIR`, and `OCO_TOOLS_TEMPLATES_DIR`
 

--- a/instances/core-human/config/instance.overrides.example.json5
+++ b/instances/core-human/config/instance.overrides.example.json5
@@ -1,4 +1,12 @@
 {
+  agents: {
+    defaults: {
+      // Keep replay order stable for reasoning/tool turns.
+      contextPruning: {
+        mode: "off",
+      },
+    },
+  },
   channels: {
     telegram: {
       dmPolicy: "pairing",

--- a/skills/thoughtful-oco-facilitator/SKILL.md
+++ b/skills/thoughtful-oco-facilitator/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: thoughtful-oco-facilitator
+description: Repository governance and rollout guardrails for OCO builders. Use when adding features, changing inventory or config layers, updating templates/examples, updating agents through the CLI, or deploying instances. Enforce docs propagation, local inventory files as source of truth, and post-change doctor/health checks.
+---
+
+# Thoughtful OCO Facilitator
+
+## Overview
+
+Apply a consistent operating checklist for OCO repo changes so configuration, docs, and runtime health stay aligned.
+
+## Propagate Through Repo
+
+- Update relevant docs whenever adding or changing a feature.
+- Keep docs concise and focused on how to configure and deploy the application.
+- Update local inventory state files after agent changes through CLI workflows.
+- Treat the active local inventory file (for example `inventory/instances.local.yaml`) as source of truth for org state.
+- Run a doctor pass after repo updates or deployed-agent updates to confirm health and security.
+- Update relevant templates and example files whenever configuration options change.
+
+## Rollout and Test Changes
+
+- Automatically restart and validate after any inventory config change.
+- Run the standard rollout sequence:
+  1. `oco validate`
+  2. `oco policy validate`
+  3. `oco render --instance <instance-id>`
+  4. `oco compose generate --instance <instance-id>`
+  5. `./scripts/deploy-instance.sh <instance-id>`
+  6. `oco health --instance <instance-id>`
+- Run doctor after rollout:
+  - `docker compose -f .generated/<instance-id>/docker-compose.yaml exec -T gateway node /app/openclaw.mjs doctor`
+
+## Response Pattern
+
+1. State the concrete files and configs changed.
+2. List docs/templates updated because of the change.
+3. Show rollout and verification commands executed.
+4. Report remaining risks or follow-up checks.

--- a/skills/thoughtful-oco-facilitator/agents/openai.yaml
+++ b/skills/thoughtful-oco-facilitator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Thoughtful OCO Facilitator"
+  short_description: "Repo-safe OCO rollout and docs guardrails"
+  default_prompt: "Use $thoughtful-oco-facilitator to implement OCO changes with docs, rollout, and health checks."

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -140,7 +140,7 @@ function resolveDockerUser(docker: Record<string, unknown>): string | undefined 
 }
 
 function injectProviderApiKeys(env: Record<string, string>): void {
-  const passthrough = ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY'];
+  const passthrough = ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY', 'BRAVE_API_KEY'];
 
   for (const key of passthrough) {
     const value = process.env[key];

--- a/templates/openclaw/org.base.json5
+++ b/templates/openclaw/org.base.json5
@@ -17,6 +17,13 @@
         // Valid values: off | non-main | all
         mode: "off",
       },
+      contextPruning: {
+        // Keep full tool/reasoning chains intact for OpenAI Responses replay safety.
+        mode: "off",
+      },
     },
+  },
+  tools: {
+    deny: ["gateway"],
   },
 }

--- a/tests/compose.test.ts
+++ b/tests/compose.test.ts
@@ -73,6 +73,7 @@ describe('compose', () => {
 
     process.env.OPENAI_API_KEY = 'env-openai-key';
     process.env.OPENROUTER_API_KEY = 'env-openrouter-key';
+    process.env.BRAVE_API_KEY = 'env-brave-key';
 
     try {
       const context: InstanceContext = {
@@ -108,9 +109,11 @@ describe('compose', () => {
 
       expect(env.OPENAI_API_KEY).toBe('env-openai-key');
       expect(env.OPENROUTER_API_KEY).toBe('env-openrouter-key');
+      expect(env.BRAVE_API_KEY).toBe('env-brave-key');
     } finally {
       delete process.env.OPENAI_API_KEY;
       delete process.env.OPENROUTER_API_KEY;
+      delete process.env.BRAVE_API_KEY;
       rmSync(root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
This PR stabilizes Telegram agent sessions on `openai/gpt-5.2` by preventing context replay mutation that can orphan OpenAI Responses reasoning items, and adds repo guidance/config updates that were part of the same rollout.

## Problem
Telegram conversations were intermittently failing with:

```text
400 Item 'rs_...' of type 'reasoning' was provided without its required following item.
```

This was observed when replaying prior turns that included reasoning + tool-call chains.

## Changes
- Disable context pruning by default in the shared OpenClaw base template.
  - `templates/openclaw/org.base.json5`
- Mirror that setting in the tracked local override example.
  - `instances/core-human/config/instance.overrides.example.json5`
- Document prevention + one-time recovery steps for already-poisoned sessions.
  - `docs/CONFIGURATION_DETAILS.md`
- Pass `BRAVE_API_KEY` into compose environment and cover it in tests/docs.
  - `src/compose.ts`
  - `tests/compose.test.ts`
  - `.env.example`
  - `README.md`
- Add a new repo skill for rollout/doc discipline.
  - `skills/thoughtful-oco-facilitator/SKILL.md`
  - `skills/thoughtful-oco-facilitator/agents/openai.yaml`

## Validation
- `bun test` (24 pass, 0 fail)
- Reproduced tool-call + follow-up session flow on `openai/gpt-5.2` after config update with no replay error
- Gateway health check passes for `core-human`

## Operational Notes
- The config fix prevents new sessions from being poisoned.
- Existing broken sessions still require a one-time session reset/new session mapping (documented in `docs/CONFIGURATION_DETAILS.md`).
