### PR TITLE
Add BetterStack uptime triage skill and wire into infra tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ oco tools apply --instance core-human --agent-id support --template operations -
 ```
 
 ## Recommended Functional Isolation
-Group by credential risk and write scope:
+Group by credential risk and write scope. For example:
 - `discord-knowledge`: read-heavy QA/research agents.
 - `discord-systems`: write-capable system-of-record agents (GitHub/Notion).
 - `discord-infra`: monitoring + incident triage agents.
@@ -119,16 +119,7 @@ Group by credential risk and write scope:
 Detailed rollout: `docs/E2E_OCO_DISCORD_FUNCTIONAL_AGENTS.md`
 
 ## Documentation
-- `docs/DEPLOYMENT_RUNBOOK.md`
-- `docs/CONFIGURATION_DETAILS.md`
-- `docs/INTEGRATIONS_AND_USE_CASES.md`
-- `docs/BOT_ACCESS_SETUP.md`
-- `docs/E2E_OCO_TELEGRAM.md`
-- `docs/E2E_OCO_DISCORD_FUNCTIONAL_AGENTS.md`
-- `docs/DATA_SOURCES_CONVENTION.md`
-- `docs/SOUL_TEMPLATES.md`
-- `docs/TOOLS_TEMPLATES.md`
-- `docs/REQUIREMENTS.md`
+Comprehensive documentation is available in `docs/`, including deployment steps, usage examples, and reusable templates.
 
 ## Open Source Safety
 - Keep secrets in local `.env` only.

--- a/inventory/instances.example.yaml
+++ b/inventory/instances.example.yaml
@@ -158,6 +158,7 @@ instances:
         integrations:
           - discord
         skills:
+          - betterstack-uptime-triage
           - github
           - coding-agent
         skill_sources:

--- a/inventory/instances.yaml
+++ b/inventory/instances.yaml
@@ -158,6 +158,7 @@ instances:
         integrations:
           - discord
         skills:
+          - betterstack-uptime-triage
           - github
           - coding-agent
         skill_sources:

--- a/skills/betterstack-uptime-triage/SKILL.md
+++ b/skills/betterstack-uptime-triage/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: betterstack-uptime-triage
+description: BetterStack Uptime incident and monitor triage workflow. Use when asked to inspect BetterStack Uptime status, summarize current incidents, identify likely impact, or propose immediate mitigation and follow-up actions based on Uptime API data.
+---
+
+# BetterStack Uptime Triage
+
+## Overview
+Use this skill to fetch BetterStack Uptime monitor and incident data, classify impact, and provide operator-ready triage output.
+
+## Execute Workflow
+1. Verify required credentials:
+- `BETTERSTACK_API_TOKEN`
+- `BETTERSTACK_API_BASE_URL` (default `https://uptime.betterstack.com/api/v2` if missing)
+
+2. Capture current Uptime signals:
+- Use `scripts/uptime_snapshot.sh` for a standard monitor+incident pull.
+- Use `scripts/uptime_get.sh` for targeted endpoint pulls.
+- Use `scripts/uptime_incident_names.sh` for incident-name summaries.
+
+3. Summarize incident state:
+- active incidents
+- affected monitors/components
+- customer/reliability impact
+- start time and current status
+
+4. Classify output explicitly:
+- facts (API-confirmed)
+- hypotheses (likely causes)
+- unknowns (data still needed)
+
+5. Recommend actions:
+- immediate containment/mitigation
+- verification steps
+- durable follow-up actions
+- owner + ETA proposal
+
+## Scripts
+
+### `scripts/uptime_snapshot.sh`
+Run a standard snapshot and store JSON files for current incidents and monitors.
+
+```bash
+bash scripts/uptime_snapshot.sh
+```
+
+### `scripts/uptime_get.sh`
+Fetch any Uptime API endpoint path quickly.
+
+```bash
+bash scripts/uptime_get.sh /incidents
+bash scripts/uptime_get.sh /monitors
+```
+
+### `scripts/uptime_incident_names.sh`
+Return incident names as a numbered list, without `jq`.
+
+```bash
+bash scripts/uptime_incident_names.sh 5
+```
+
+## Critical Rules
+- Do not use `jq` (it is unavailable in this runtime).
+- Do not call `/api/v1/*` endpoints.
+- Do not append `/api/v2` manually if `BETTERSTACK_API_BASE_URL` already includes it.
+- Prefer the provided scripts over ad-hoc curl commands.
+
+## Output Contract
+Return triage output in this order:
+1. Current status
+2. Impact summary
+3. Findings (fact/hypothesis/unknown)
+4. Immediate actions
+5. Follow-up plan
+
+## Guardrails
+- Do not claim incident resolution without verification evidence.
+- Do not execute production changes without explicit operator approval.
+- Keep recommendations reversible first, invasive changes second.
+
+## References
+- BetterStack Uptime API quick start and endpoint patterns: `references/uptime-api.md`

--- a/skills/betterstack-uptime-triage/agents/openai.yaml
+++ b/skills/betterstack-uptime-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BetterStack Uptime Triage"
+  short_description: "Triage BetterStack Uptime incidents and monitors."
+  default_prompt: "Analyze BetterStack Uptime monitors and incidents, summarize impact and likely causes, and propose concrete mitigations with owner-ready next steps."

--- a/skills/betterstack-uptime-triage/references/uptime-api.md
+++ b/skills/betterstack-uptime-triage/references/uptime-api.md
@@ -1,0 +1,22 @@
+# BetterStack Uptime API Reference Notes
+
+Primary docs:
+- Getting started: https://betterstack.com/docs/uptime/api/getting-started-with-uptime-api/
+- Monitors endpoint index: https://betterstack.com/docs/uptime/api/list-all-existing-monitors/
+- Incidents endpoint index: https://betterstack.com/docs/uptime/api/list-existing-incidents/
+
+## Authentication
+Use bearer token auth via `Authorization: Bearer <token>`.
+
+## Base URL
+Default Uptime API base URL shown in docs:
+- `https://uptime.betterstack.com/api/v2`
+
+## Common Triage Endpoints
+- `/monitors`
+- `/incidents`
+
+Use monitor and incident payloads together for:
+- current outage scope
+- impacted services/components
+- incident timeline and status

--- a/skills/betterstack-uptime-triage/scripts/uptime_get.sh
+++ b/skills/betterstack-uptime-triage/scripts/uptime_get.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BETTERSTACK_API_BASE_URL:-https://uptime.betterstack.com/api/v2}"
+API_TOKEN="${BETTERSTACK_API_TOKEN:?BETTERSTACK_API_TOKEN is required}"
+ENDPOINT_PATH="${1:-/incidents}"
+
+if [[ "$ENDPOINT_PATH" != /* ]]; then
+  ENDPOINT_PATH="/$ENDPOINT_PATH"
+fi
+
+curl -sS "${BASE_URL%/}${ENDPOINT_PATH}" \
+  -H "Authorization: Bearer ${API_TOKEN}" \
+  -H "Content-Type: application/json"

--- a/skills/betterstack-uptime-triage/scripts/uptime_incident_names.sh
+++ b/skills/betterstack-uptime-triage/scripts/uptime_incident_names.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BETTERSTACK_API_BASE_URL:-https://uptime.betterstack.com/api/v2}"
+API_TOKEN="${BETTERSTACK_API_TOKEN:?BETTERSTACK_API_TOKEN is required}"
+LIMIT="${1:-5}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+  echo "limit must be an integer" >&2
+  exit 2
+fi
+
+TMP_JSON="$(mktemp)"
+trap 'rm -f "$TMP_JSON"' EXIT
+
+curl -sS "${BASE_URL%/}/incidents" \
+  -H "Authorization: Bearer ${API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  > "$TMP_JSON"
+
+node - "$TMP_JSON" "$LIMIT" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const limit = Number.parseInt(process.argv[3], 10);
+const raw = fs.readFileSync(file, 'utf8');
+let doc;
+try {
+  doc = JSON.parse(raw);
+} catch (err) {
+  console.error('invalid JSON from BetterStack incidents endpoint');
+  process.exit(3);
+}
+
+const rows = Array.isArray(doc?.data) ? doc.data : [];
+const names = rows
+  .map((item) => item?.attributes?.name)
+  .filter((v) => typeof v === 'string' && v.trim().length > 0)
+  .slice(0, limit);
+
+if (names.length === 0) {
+  console.log('No incident names found.');
+  process.exit(0);
+}
+
+for (let i = 0; i < names.length; i += 1) {
+  console.log(`${i + 1}. ${names[i]}`);
+}
+NODE

--- a/skills/betterstack-uptime-triage/scripts/uptime_snapshot.sh
+++ b/skills/betterstack-uptime-triage/scripts/uptime_snapshot.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BETTERSTACK_API_BASE_URL:-https://uptime.betterstack.com/api/v2}"
+API_TOKEN="${BETTERSTACK_API_TOKEN:?BETTERSTACK_API_TOKEN is required}"
+OUT_DIR="${1:-/tmp/betterstack-uptime-snapshot}"
+mkdir -p "$OUT_DIR"
+
+curl -sS "${BASE_URL%/}/incidents" \
+  -H "Authorization: Bearer ${API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  > "$OUT_DIR/incidents.json"
+
+curl -sS "${BASE_URL%/}/monitors" \
+  -H "Authorization: Bearer ${API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  > "$OUT_DIR/monitors.json"
+
+printf 'wrote %s\n' "$OUT_DIR/incidents.json"
+printf 'wrote %s\n' "$OUT_DIR/monitors.json"

--- a/templates/tools/infra-triage.md
+++ b/templates/tools/infra-triage.md
@@ -19,6 +19,14 @@
 curl -sS "$BETTERSTACK_API_BASE_URL" -H "Authorization: Bearer $BETTERSTACK_API_TOKEN" -H "Content-Type: application/json"
 ```
 
+`jq` may be unavailable in some runtimes. Prefer `node`/`python` JSON parsing or skill scripts.
+
+Preferred incident-name command:
+
+```bash
+bash skills/betterstack-uptime-triage/scripts/uptime_incident_names.sh 5
+```
+
 ## Triage Workflow
 
 1. Capture current alerts/incidents from Better Stack.


### PR DESCRIPTION
## Summary
- add new `betterstack-uptime-triage` skill with workflow docs, API notes, and helper scripts
- wire the skill into infra-triage guidance and instance skill lists
- simplify top-level README docs section wording

## Validation
- `bash -n skills/betterstack-uptime-triage/scripts/uptime_get.sh`
- `bash -n skills/betterstack-uptime-triage/scripts/uptime_incident_names.sh`
- `bash -n skills/betterstack-uptime-triage/scripts/uptime_snapshot.sh`

## Notes
- intentionally excluded maestro-specific override edits from this PR.