### PR TITLE
Add generic multi-org examples and move defaults to GPT-5.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,19 +11,15 @@ BRAVE_API_KEY=
 
 # Telegram default-account fallback token (single-account setup).
 TELEGRAM_BOT_TOKEN=
-# Telegram multi-account bot tokens used by instances/core-human/config/instance.overrides.json5
-TELEGRAM_BOT_TOKEN_VBARSEGYAN=
-TELEGRAM_BOT_TOKEN_DRICHARDSON=
-TELEGRAM_BOT_TOKEN_SAUGUSTINE=
+# Telegram multi-account bot tokens (copy/rename per account).
+TELEGRAM_BOT_TOKEN_OWNER=
+TELEGRAM_BOT_TOKEN_SUPPORT=
 
 # Discord default-account fallback token (single-account setup).
 DISCORD_BOT_TOKEN=
-# Discord multi-account bot tokens used by Maestro Discord instances.
-DISCORD_BOT_TOKEN_BRAIN_QA=
-DISCORD_BOT_TOKEN_DEEP_RESEARCH=
-DISCORD_BOT_TOKEN_GITHUB_MANAGER=
-DISCORD_BOT_TOKEN_NOTION_MANAGER=
-DISCORD_BOT_TOKEN_INFRA_TRIAGE=
+# Discord multi-account bot tokens (copy/rename per account).
+DISCORD_BOT_TOKEN_RESEARCH=
+DISCORD_BOT_TOKEN_OPERATIONS=
 
 # Tool/API credentials used by use-case agent templates.
 GITHUB_TOKEN=
@@ -31,3 +27,16 @@ BETTERSTACK_API_TOKEN=
 BETTERSTACK_API_BASE_URL=
 
 NOTION_API_KEY=
+
+# Optional org-scoped credentials for isolated multi-org operations.
+# Use per-org prefixes (for example, ORG_A_* and ORG_B_*).
+ORG_A_OPENCLAW_GATEWAY_TOKEN=
+ORG_A_OPENAI_API_KEY=
+ORG_A_ANTHROPIC_API_KEY=
+ORG_A_OPENROUTER_API_KEY=
+ORG_A_BRAVE_API_KEY=
+ORG_A_GITHUB_TOKEN=
+ORG_A_NOTION_API_KEY=
+ORG_A_BETTERSTACK_API_TOKEN=
+ORG_A_BETTERSTACK_API_BASE_URL=
+ORG_A_TELEGRAM_BOT_TOKEN_OWNER=

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ instances/*/config/openclaw.json5
 instances/*/config/openclaw.json5.bak*
 instances/*/config/*.resolved.json
 instances/*/config/instance.overrides.json5
+orgs/*/instances/*/state/
+orgs/*/instances/*/workspaces/
+orgs/*/instances/*/config/openclaw.json5
+orgs/*/instances/*/config/openclaw.json5.bak*
+orgs/*/instances/*/config/*.resolved.json
+orgs/*/instances/*/config/instance.overrides.json5
 
 # Misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Edit `inventory/instances.local.yaml` (recommended) for:
 - channel accounts + agent bindings
 - policy allow/deny defaults
 
+For isolated multi-org setups, use one inventory per org:
+- `inventory/<org>.instances.local.yaml` (local, gitignored), or
+- `inventory/<org>.instances.yaml` (tracked template/reference).
+
+A generic multi-org example is available at `inventory/org.instances.example.yaml`.
+
 Path resolution order:
 1. `--inventory <path>`
 2. `OCO_INVENTORY_PATH`
@@ -79,6 +85,11 @@ source .env
 set +a
 ```
 
+For multi-org isolation, keep secrets in separate files (for example `.env.acme`, `.env.beta-org`) and load via:
+```bash
+ORG_ENV_FILE=.env.acme ./scripts/org.sh acme validate
+```
+
 ### 4. Validate and Deploy
 ```bash
 oco validate
@@ -99,7 +110,7 @@ oco agent add \
   --role usecase \
   --account telegram:support \
   --integration telegram \
-  --model openai/gpt-4.1-mini \
+  --model openai/gpt-5.1 \
   --soul-template operations \
   --tools-template operations
 ```
@@ -108,6 +119,13 @@ Apply templates to an existing agent:
 ```bash
 oco soul apply --instance core-human --agent-id support --template operations --force
 oco tools apply --instance core-human --agent-id support --template operations --force
+```
+
+Run org-scoped commands with the helper script:
+```bash
+./scripts/org.sh <org> validate
+./scripts/org.sh <org> compose up --instance <instance-id>
+./scripts/org.sh <org> health --instance <instance-id>
 ```
 
 ## Recommended Functional Isolation

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -38,6 +38,8 @@ Notes:
 - `inventory/instances.local.yaml` is gitignored.
 - `oco` auto-selects it when present.
 - override with `--inventory <path>` or `OCO_INVENTORY_PATH`.
+- For isolated multi-org operations, use `inventory/<org>.instances.local.yaml` or `inventory/<org>.instances.yaml`.
+- See `inventory/org.instances.example.yaml` for a reusable pattern.
 
 ## 4. Configure Secrets
 ```bash
@@ -54,6 +56,11 @@ Load env:
 set -a
 source .env
 set +a
+```
+
+For isolated multi-org secret management, keep one env file per org and run commands with:
+```bash
+ORG_ENV_FILE=.env.<org> ./scripts/org.sh <org> validate
 ```
 
 ## 5. Validate Before Deploy
@@ -82,10 +89,16 @@ For multi-instance functional deployments, deploy each target instance:
 ./scripts/deploy-instance.sh <instance-id>
 ```
 
+For org-specific deployments:
+```bash
+./scripts/org.sh <org> compose up --instance <instance-id>
+./scripts/org.sh <org> health --instance <instance-id>
+```
+
 ## 7. Agent Operations
 Add an agent:
 ```bash
-./scripts/add-agent.sh core-human procurement usecase telegram:procurement openai/gpt-4.1-mini
+./scripts/add-agent.sh core-human procurement usecase telegram:procurement openai/gpt-5.1
 ```
 
 Manual equivalent:
@@ -96,7 +109,7 @@ oco agent add \
   --role usecase \
   --account telegram:procurement \
   --integration telegram \
-  --model openai/gpt-4.1-mini
+  --model openai/gpt-5.1
 oco compose restart --instance core-human
 ```
 

--- a/docs/E2E_OCO_TELEGRAM.md
+++ b/docs/E2E_OCO_TELEGRAM.md
@@ -59,7 +59,7 @@ instances:
         role: human
         workspace: owner
         agent_dir: agents/owner
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations: [telegram]
         bindings:
           - match:
@@ -69,7 +69,7 @@ instances:
         role: usecase
         workspace: research
         agent_dir: agents/research
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations: [telegram]
         bindings:
           - match:

--- a/docs/SOUL_TEMPLATES.md
+++ b/docs/SOUL_TEMPLATES.md
@@ -42,7 +42,7 @@ oco agent add \
   --role usecase \
   --account telegram:support \
   --integration telegram \
-  --model openai/gpt-4.1-mini \
+  --model openai/gpt-5.1 \
   --soul-template operations
 ```
 

--- a/docs/TOOLS_TEMPLATES.md
+++ b/docs/TOOLS_TEMPLATES.md
@@ -42,7 +42,7 @@ oco agent add \
   --role usecase \
   --account telegram:support \
   --integration telegram \
-  --model openai/gpt-4.1-mini \
+  --model openai/gpt-5.1 \
   --tools-template operations
 ```
 

--- a/instances/maestro-discord-infra/config/instance.overrides.example.json5
+++ b/instances/maestro-discord-infra/config/instance.overrides.example.json5
@@ -1,6 +1,11 @@
 {
   channels: {
     discord: {
+      groupPolicy: "allowlist",
+      guilds: {
+        // Add one or more Discord guild IDs your bot is allowed to process.
+        "YOUR_DISCORD_GUILD_ID": {},
+      },
       accounts: {
         infra_triage: {
           token: "${DISCORD_BOT_TOKEN_INFRA_TRIAGE}",

--- a/inventory/instances.example.yaml
+++ b/inventory/instances.example.yaml
@@ -89,7 +89,7 @@ instances:
         role: human
         workspace: vbarsegyan
         agent_dir: agents/vbarsegyan
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - telegram
         skills:
@@ -105,7 +105,7 @@ instances:
         role: human
         workspace: drichardson
         agent_dir: agents/drichardson
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - telegram
         skills:
@@ -154,7 +154,7 @@ instances:
         role: usecase
         workspace: brain-qa
         agent_dir: agents/brain-qa
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -172,7 +172,7 @@ instances:
         role: usecase
         workspace: deep-research
         agent_dir: agents/deep-research
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -223,7 +223,7 @@ instances:
         role: usecase
         workspace: github-manager
         agent_dir: agents/github-manager
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -240,7 +240,7 @@ instances:
         role: usecase
         workspace: notion-manager
         agent_dir: agents/notion-manager
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -289,7 +289,7 @@ instances:
         role: usecase
         workspace: infra-triage
         agent_dir: agents/infra-triage
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:

--- a/inventory/instances.yaml
+++ b/inventory/instances.yaml
@@ -89,7 +89,7 @@ instances:
         role: human
         workspace: vbarsegyan
         agent_dir: agents/vbarsegyan
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - telegram
         skills:
@@ -105,7 +105,7 @@ instances:
         role: human
         workspace: drichardson
         agent_dir: agents/drichardson
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - telegram
         skills:
@@ -154,7 +154,7 @@ instances:
         role: usecase
         workspace: brain-qa
         agent_dir: agents/brain-qa
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -172,7 +172,7 @@ instances:
         role: usecase
         workspace: deep-research
         agent_dir: agents/deep-research
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -223,7 +223,7 @@ instances:
         role: usecase
         workspace: github-manager
         agent_dir: agents/github-manager
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -240,7 +240,7 @@ instances:
         role: usecase
         workspace: notion-manager
         agent_dir: agents/notion-manager
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:
@@ -289,7 +289,7 @@ instances:
         role: usecase
         workspace: infra-triage
         agent_dir: agents/infra-triage
-        model: openai/gpt-4.1-mini
+        model: openai/gpt-5.1
         integrations:
           - discord
         skills:

--- a/inventory/org.instances.example.yaml
+++ b/inventory/org.instances.example.yaml
@@ -1,0 +1,78 @@
+version: 1
+organization:
+  org_id: example-org
+  org_slug: example-org
+  display_name: Example Org
+defaults:
+  port_stride: 20
+  policy:
+    integrations:
+      allow:
+        - telegram
+      deny: []
+    skills:
+      allow: []
+      deny: []
+      allow_sources:
+        - bundled
+        - managed
+        - workspace
+      deny_sources: []
+    models:
+      allow_providers:
+        - openai
+        - anthropic
+      deny_providers: []
+      allow_models: []
+      deny_models: []
+instances:
+  - id: example-org-core-human
+    enabled: true
+    profile: human
+    host:
+      bind: 127.0.0.1
+      gateway_port: 20789
+    paths:
+      config_dir: ../orgs/example-org/instances/core-human/config
+      state_dir: ../orgs/example-org/instances/core-human/state
+      workspace_root: ../orgs/example-org/instances/core-human/workspaces
+      generated_dir: ../.generated/example-org-core-human
+    openclaw:
+      config_layers:
+        - ../templates/openclaw/org.base.json5
+        - ../templates/openclaw/profiles/human.base.json5
+        - ../orgs/example-org/instances/core-human/config/instance.overrides.example.json5
+      docker:
+        image: ghcr.io/openclaw/openclaw:latest
+        container_name: openclaw-example-org-core-human
+        restart: unless-stopped
+        environment:
+          OPENAI_API_KEY: ${EXAMPLE_ORG_OPENAI_API_KEY}
+          ANTHROPIC_API_KEY: ${EXAMPLE_ORG_ANTHROPIC_API_KEY}
+    policy:
+      integrations:
+        allow:
+          - telegram
+      models:
+        allow_providers:
+          - openai
+          - anthropic
+    channels:
+      telegram:
+        accounts:
+          owner: {}
+    agents:
+      - id: owner
+        name: Org Owner
+        role: human
+        workspace: owner
+        agent_dir: agents/owner
+        model: openai/gpt-5.1
+        integrations:
+          - telegram
+        skill_sources:
+          - bundled
+        bindings:
+          - match:
+              channel: telegram
+              accountId: owner

--- a/orgs/example-org/instances/core-human/config/instance.overrides.example.json5
+++ b/orgs/example-org/instances/core-human/config/instance.overrides.example.json5
@@ -1,0 +1,25 @@
+{
+  gateway: {
+    auth: {
+      token: "${EXAMPLE_ORG_OPENCLAW_GATEWAY_TOKEN}",
+    },
+  },
+  agents: {
+    defaults: {
+      contextPruning: {
+        mode: "off",
+      },
+    },
+  },
+  channels: {
+    telegram: {
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+      accounts: {
+        owner: {
+          botToken: "${EXAMPLE_ORG_TELEGRAM_BOT_TOKEN_OWNER}",
+        },
+      },
+    },
+  },
+}

--- a/scripts/add-agent.sh
+++ b/scripts/add-agent.sh
@@ -5,7 +5,7 @@ if [[ "$#" -lt 4 ]]; then
   cat >&2 <<USAGE
 Usage: $0 <instance-id> <agent-id> <role> <channel:accountId> [model]
 Example:
-  $0 core-human procurement usecase telegram:procurement openai/gpt-4.1-mini
+  $0 core-human procurement usecase telegram:procurement openai/gpt-5.1
 USAGE
   exit 1
 fi

--- a/scripts/org.sh
+++ b/scripts/org.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -lt 2 ]]; then
+  cat >&2 <<USAGE
+Usage: $0 <org> <oco-args...>
+Examples:
+  $0 acme validate
+  $0 acme compose ps --instance core-human
+  $0 beta-org compose up --instance core-human
+USAGE
+  exit 1
+fi
+
+ORG_RAW="$1"
+shift
+
+ORG="$(printf '%s' "$ORG_RAW" | tr '[:upper:]' '[:lower:]')"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OCO="$ROOT_DIR/scripts/oco.sh"
+
+INV_LOCAL="inventory/${ORG}.instances.local.yaml"
+INV_TRACKED="inventory/${ORG}.instances.yaml"
+if [[ -f "$ROOT_DIR/$INV_LOCAL" ]]; then
+  INVENTORY_PATH="$INV_LOCAL"
+elif [[ -f "$ROOT_DIR/$INV_TRACKED" ]]; then
+  INVENTORY_PATH="$INV_TRACKED"
+elif [[ "$ORG" == "maestro" && -f "$ROOT_DIR/inventory/instances.local.yaml" ]]; then
+  INVENTORY_PATH="inventory/instances.local.yaml"
+elif [[ "$ORG" == "maestro" && -f "$ROOT_DIR/inventory/instances.yaml" ]]; then
+  INVENTORY_PATH="inventory/instances.yaml"
+else
+  echo "error: no inventory found for org '$ORG' (expected $INV_LOCAL or $INV_TRACKED)" >&2
+  exit 1
+fi
+
+ENV_FILE="${ORG_ENV_FILE:-.env.${ORG}}"
+if [[ -f "$ROOT_DIR/$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ROOT_DIR/$ENV_FILE"
+  set +a
+fi
+
+exec "$OCO" --inventory "$INVENTORY_PATH" "$@"

--- a/templates/souls/founder.md
+++ b/templates/souls/founder.md
@@ -1,0 +1,32 @@
+# SOUL.md
+
+## Identity and Mission
+- You are {{AGENT_NAME}} ({{AGENT_ID}}), a founder at {{ORG_NAME}}.
+- Your mission is to drive strategic clarity, operational focus, and accountable execution.
+
+## Core Responsibilities
+- Frame decisions using business impact, risk, and timing.
+- Keep teams aligned on top priorities and expected outcomes.
+- Resolve cross-functional blockers with clear owners and deadlines.
+- Ensure communication to stakeholders is concise and decision-ready.
+
+## Decision Principles
+- Optimize for customer value, speed, and long-term leverage.
+- Prioritize high-signal actions over broad low-confidence work.
+- Surface tradeoffs explicitly (cost, risk, timeline, quality).
+- Escalate quickly when execution drifts from goals.
+
+## Communication Style
+- Be direct, calm, and outcome-oriented.
+- Ask for the minimum context needed to decide.
+- End responses with a recommendation and clear next step.
+
+## Working Context
+- Primary role: {{AGENT_ROLE}}
+- Primary routing: {{PRIMARY_CHANNEL}} / {{PRIMARY_ACCOUNT_ID}}
+- Active bindings: {{BINDINGS}}
+
+## Boundaries
+- Do not make legal or financial commitments without explicit approval.
+- Do not share confidential company data outside authorized channels.
+- Do not assume unresolved risks are acceptable; call them out clearly.

--- a/templates/souls/sales.md
+++ b/templates/souls/sales.md
@@ -1,0 +1,32 @@
+# SOUL.md
+
+## Identity and Mission
+- You are {{AGENT_NAME}} ({{AGENT_ID}}), a sales lead at {{ORG_NAME}}.
+- Your mission is to advance revenue by qualifying opportunities, removing buying friction, and keeping pipeline execution disciplined.
+
+## Core Responsibilities
+- Qualify inbound/outbound opportunities with clear ICP fit signals.
+- Drive deal progression with concrete next steps and stakeholder mapping.
+- Translate customer needs into value articulation and proposal inputs.
+- Keep pipeline updates current, specific, and forecast-relevant.
+
+## Sales Operating Principles
+- Prioritize high-likelihood, high-value opportunities.
+- Keep commitments explicit with owner and target date.
+- Escalate competitive or legal risk early.
+- Maintain rigorous follow-up cadence without noise.
+
+## Communication Style
+- Be concise, confident, and customer-outcome focused.
+- Separate what is confirmed from what is assumed.
+- Always end with next action and meeting objective.
+
+## Working Context
+- Primary role: {{AGENT_ROLE}}
+- Primary routing: {{PRIMARY_CHANNEL}} / {{PRIMARY_ACCOUNT_ID}}
+- Active bindings: {{BINDINGS}}
+
+## Boundaries
+- Do not commit to legal, security, or pricing terms without approval.
+- Do not share confidential customer or internal data outside authorized channels.
+- Do not present unvalidated product capability as guaranteed.

--- a/templates/souls/software-engineer.md
+++ b/templates/souls/software-engineer.md
@@ -1,0 +1,32 @@
+# SOUL.md
+
+## Identity and Mission
+- You are {{AGENT_NAME}} ({{AGENT_ID}}), a software engineer at {{ORG_NAME}}.
+- Your mission is to deliver reliable software changes quickly with strong engineering quality.
+
+## Core Responsibilities
+- Convert product and operational needs into concrete implementation plans.
+- Produce code changes that are testable, reviewable, and safe to roll out.
+- Investigate incidents and defects to root cause, then document remediation.
+- Keep technical decisions explicit with tradeoffs and risks.
+
+## Engineering Standards
+- Prefer small, reversible changes over broad refactors.
+- Maintain clear test coverage for behavior changes.
+- Validate assumptions before mutating production-critical systems.
+- Leave code and docs clearer than you found them.
+
+## Communication Style
+- Be direct and concise.
+- Separate facts, assumptions, and recommendations.
+- Report status as: current state, blockers, next action.
+
+## Working Context
+- Primary role: {{AGENT_ROLE}}
+- Primary routing: {{PRIMARY_CHANNEL}} / {{PRIMARY_ACCOUNT_ID}}
+- Active bindings: {{BINDINGS}}
+
+## Boundaries
+- Do not merge risky or high-impact changes without explicit approval.
+- Do not expose secrets, credentials, or sensitive internal data.
+- If context is missing, ask focused clarifying questions before implementation.

--- a/templates/tools/founder.md
+++ b/templates/tools/founder.md
@@ -1,0 +1,34 @@
+# TOOLS.md
+
+## Operator Notes
+
+- Agent: `{{AGENT_NAME}}` (`{{AGENT_ID}}`)
+- Role: `{{AGENT_ROLE}}`
+- Organization: `{{ORG_NAME}}`
+- Primary binding: `{{PRIMARY_CHANNEL}}:{{PRIMARY_ACCOUNT_ID}}`
+
+## Executive Workflow
+
+1. Define the decision to be made and desired outcome.
+2. Collect only decision-critical facts.
+3. Present options with tradeoffs and a recommendation.
+4. Assign owner, timeline, and follow-up checkpoint.
+
+## Notion
+
+- `NOTION_API_KEY` is expected to be preconfigured by operators.
+- Validate connectivity when needed:
+
+```bash
+curl -sS https://api.notion.com/v1/users/me -H "Authorization: Bearer $NOTION_API_KEY" -H "Notion-Version: 2025-09-03" -H "Content-Type: application/json"
+```
+
+## GitHub
+
+- `GITHUB_TOKEN` should be available for repo/PR visibility.
+- For high-impact repository actions, require explicit operator approval first.
+
+## Change Safety
+
+- No irreversible actions without explicit confirmation.
+- Summaries should always include: decision, owner, due date, risk.

--- a/templates/tools/sales.md
+++ b/templates/tools/sales.md
@@ -1,0 +1,27 @@
+# TOOLS.md
+
+## Operator Notes
+
+- Agent: `{{AGENT_NAME}}` (`{{AGENT_ID}}`)
+- Role: `{{AGENT_ROLE}}`
+- Organization: `{{ORG_NAME}}`
+- Primary binding: `{{PRIMARY_CHANNEL}}:{{PRIMARY_ACCOUNT_ID}}`
+
+## Sales Workflow
+
+1. Confirm account context, stage, and buying timeline.
+2. Identify blocker, stakeholder, and required proof point.
+3. Recommend next best action with owner and deadline.
+4. Update pipeline summary with confidence and risk.
+
+## Research and Account Prep
+
+- Use available CRM/notes systems provided by operators.
+- Prefer concise account briefs: goals, pain, blockers, next meeting objective.
+- Track mutual action plans for active opportunities.
+
+## Communication Guardrails
+
+- Avoid over-committing on roadmap, pricing, legal, or security.
+- Escalate deal-risk signals early (procurement stall, security concerns, no champion).
+- Keep all customer-facing drafts specific and measurable.

--- a/templates/tools/software-engineer.md
+++ b/templates/tools/software-engineer.md
@@ -1,0 +1,31 @@
+# TOOLS.md
+
+## Operator Notes
+
+- Agent: `{{AGENT_NAME}}` (`{{AGENT_ID}}`)
+- Role: `{{AGENT_ROLE}}`
+- Organization: `{{ORG_NAME}}`
+- Primary binding: `{{PRIMARY_CHANNEL}}:{{PRIMARY_ACCOUNT_ID}}`
+
+## Default Engineering Workflow
+
+1. Confirm objective, constraints, and expected output.
+2. Gather current repo/runtime state before proposing changes.
+3. Propose smallest viable change plan.
+4. Implement, validate, and report exact results.
+
+## GitHub
+
+- `GITHUB_TOKEN` is expected to be preconfigured by operators.
+- Confirm auth before write operations:
+
+```bash
+curl -sS https://api.github.com/user -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json"
+```
+
+## Change Safety
+
+- Show plan before high-impact write operations.
+- Run relevant tests for touched scope before finalizing.
+- Include rollback notes when changing runtime behavior.
+- Prefer explicit file/line references in summaries.

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -21,7 +21,7 @@ describe('agents', () => {
       ['telegram:qa_bot'],
       ['telegram'],
       ['qa-review'],
-      'openai/gpt-4.1-mini',
+      'openai/gpt-5.1',
     );
 
     const agents = listAgents(instance);

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -52,7 +52,7 @@ describe('render', () => {
         agents: [
           {
             id: 'alex',
-            model: 'openai/gpt-4.1-mini',
+            model: 'openai/gpt-5.1',
             bindings: [{ match: { channel: 'telegram', accountId: 'alex' } }],
           },
         ],
@@ -72,8 +72,8 @@ describe('render', () => {
       expect(auth.token).toBe('from-env-token');
       expect(bindings[0].agentId).toBe('alex');
       expect(accounts.alex).toEqual({});
-      expect(agents[0].model).toBe('openai/gpt-4.1-mini');
-      expect((agentDefaults.model as Record<string, unknown>).primary).toBe('openai/gpt-4.1-mini');
+      expect(agents[0].model).toBe('openai/gpt-5.1');
+      expect((agentDefaults.model as Record<string, unknown>).primary).toBe('openai/gpt-5.1');
 
       expect(existsSync(result.generatedPath)).toBe(true);
       expect(existsSync(join(root, 'instances', 'core', 'config', 'openclaw.json5'))).toBe(true);


### PR DESCRIPTION
## Summary
- switch default model references from `openai/gpt-4.1-mini` to `openai/gpt-5.1` in docs, scripts, inventories, and tests
- add new reusable role templates: `founder`, `software-engineer`, and `sales` for both soul/tools
- add `scripts/org.sh` to run org-scoped commands with `inventory/<org>.instances(.local).yaml` and optional `ORG_ENV_FILE`
- add generic multi-org examples:
  - `inventory/org.instances.example.yaml`
  - `orgs/example-org/instances/core-human/config/instance.overrides.example.json5`
- expand gitignore for org-scoped runtime/generated secret-bearing files under `orgs/*`
- sanitize examples to avoid checking in org/person-specific data:
  - `.env.example` now uses neutral variable names and generic org prefixes (`ORG_A_*`)
  - discord allowlist example now uses `YOUR_DISCORD_GUILD_ID`

## Why
We want upstream templates/examples to stay organization-agnostic while still supporting isolated multi-org operations cleanly.

## Validation
- `bun test`

## Safety / data handling
- no concrete org names, human identities, or org-specific secrets were added to templates/examples in this PR
- all new example files use placeholder org/account identifiers only
