### PR TITLE
Improve Telegram guard visibility and reduce token bloat

### DIFF
--- a/instances/core-human/config/extensions/telegram-group-allowlist-guard/openclaw.plugin.json
+++ b/instances/core-human/config/extensions/telegram-group-allowlist-guard/openclaw.plugin.json
@@ -13,6 +13,15 @@
       },
       "maxSenderAgeMs": {
         "type": "number"
+      },
+      "awarenessSenderAgeMs": {
+        "type": "number"
+      },
+      "awarenessMaxGroups": {
+        "type": "number"
+      },
+      "stateAgentsDir": {
+        "type": "string"
       }
     }
   },
@@ -24,6 +33,18 @@
     "maxSenderAgeMs": {
       "label": "Sender Cache TTL",
       "help": "Maximum age in milliseconds for last inbound sender context."
+    },
+    "awarenessSenderAgeMs": {
+      "label": "Awareness TTL",
+      "help": "Maximum age in milliseconds for group awareness snippets in DM context."
+    },
+    "awarenessMaxGroups": {
+      "label": "Awareness Group Limit",
+      "help": "Maximum number of recent groups included in DM awareness context."
+    },
+    "stateAgentsDir": {
+      "label": "State Agents Directory",
+      "help": "Path to agent session indexes used to hydrate known groups."
     }
   }
 }

--- a/instances/core-human/config/extensions/transcript-size-guard/index.ts
+++ b/instances/core-human/config/extensions/transcript-size-guard/index.ts
@@ -1,0 +1,199 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+type TranscriptSizeGuardConfig = {
+  maxChars?: number;
+  headChars?: number;
+  tailChars?: number;
+  truncateDetails?: boolean;
+  tools?: string[];
+};
+
+type TruncateSettings = {
+  maxChars: number;
+  headChars: number;
+  tailChars: number;
+  truncateDetails: boolean;
+  toolAllowlist: Set<string> | null;
+};
+
+type TrimResult<T> = {
+  value: T;
+  changed: boolean;
+};
+
+const DEFAULT_MAX_CHARS = 12000;
+const DEFAULT_HEAD_CHARS = 4000;
+const DEFAULT_TAIL_CHARS = 3000;
+
+function toPositiveInt(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return fallback;
+}
+
+function toBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return fallback;
+}
+
+function normalizeToolAllowlist(value: unknown): Set<string> | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const normalized = value
+    .map((entry) => (typeof entry === "string" ? entry.trim().toLowerCase() : ""))
+    .filter((entry) => entry.length > 0);
+  if (normalized.length === 0) {
+    return null;
+  }
+  return new Set(normalized);
+}
+
+function resolveSettings(config: TranscriptSizeGuardConfig | undefined): TruncateSettings {
+  const maxChars = toPositiveInt(config?.maxChars, DEFAULT_MAX_CHARS);
+  let headChars = toPositiveInt(config?.headChars, DEFAULT_HEAD_CHARS);
+  let tailChars = toPositiveInt(config?.tailChars, DEFAULT_TAIL_CHARS);
+  if (headChars + tailChars >= maxChars) {
+    const budget = Math.max(2, maxChars - 1);
+    headChars = Math.max(1, Math.floor((budget * 2) / 3));
+    tailChars = Math.max(1, budget - headChars);
+  }
+  return {
+    maxChars,
+    headChars,
+    tailChars,
+    truncateDetails: toBoolean(config?.truncateDetails, true),
+    toolAllowlist: normalizeToolAllowlist(config?.tools),
+  };
+}
+
+function truncateString(
+  input: string,
+  settings: TruncateSettings,
+  label: string,
+): TrimResult<string> {
+  if (input.length <= settings.maxChars) {
+    return {
+      value: input,
+      changed: false,
+    };
+  }
+  const removed = input.length - settings.headChars - settings.tailChars;
+  return {
+    value:
+      `${input.slice(0, settings.headChars)}\n` +
+      `...[${label} truncated ${removed} chars]...\n` +
+      `${input.slice(-settings.tailChars)}`,
+    changed: true,
+  };
+}
+
+function trimUnknownDeep(value: unknown, settings: TruncateSettings, label: string): TrimResult<unknown> {
+  if (typeof value === "string") {
+    return truncateString(value, settings, label);
+  }
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((entry) => {
+      const trimmed = trimUnknownDeep(entry, settings, label);
+      if (trimmed.changed) {
+        changed = true;
+      }
+      return trimmed.value;
+    });
+    return { value: next, changed };
+  }
+  if (!value || typeof value !== "object") {
+    return { value, changed: false };
+  }
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const trimmed = trimUnknownDeep(entry, settings, `${label}:${key}`);
+    next[key] = trimmed.value;
+    if (trimmed.changed) {
+      changed = true;
+    }
+  }
+  return { value: next, changed };
+}
+
+function isToolResultMessage(message: unknown): message is Record<string, unknown> {
+  return Boolean(
+    message &&
+      typeof message === "object" &&
+      (message as Record<string, unknown>).role === "toolResult",
+  );
+}
+
+function shouldProcessTool(toolAllowlist: Set<string> | null, toolName: unknown): boolean {
+  if (!toolAllowlist || toolAllowlist.size === 0) {
+    return true;
+  }
+  if (typeof toolName !== "string") {
+    return false;
+  }
+  return toolAllowlist.has(toolName.trim().toLowerCase());
+}
+
+function cloneMessage<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export default function register(api: OpenClawPluginApi): void {
+  const settings = resolveSettings((api.pluginConfig ?? {}) as TranscriptSizeGuardConfig);
+
+  api.on("tool_result_persist", (event) => {
+    if (!shouldProcessTool(settings.toolAllowlist, event.toolName)) {
+      return;
+    }
+    if (!isToolResultMessage(event.message)) {
+      return;
+    }
+
+    const next = cloneMessage(event.message);
+    let changed = false;
+
+    if (Array.isArray(next.content)) {
+      next.content = next.content.map((part) => {
+        if (!part || typeof part !== "object") {
+          return part;
+        }
+        const text = (part as Record<string, unknown>).text;
+        if (typeof text !== "string") {
+          return part;
+        }
+        const trimmed = truncateString(text, settings, "toolResult.content");
+        if (!trimmed.changed) {
+          return part;
+        }
+        changed = true;
+        return {
+          ...(part as Record<string, unknown>),
+          text: trimmed.value,
+        };
+      });
+    }
+
+    if (settings.truncateDetails && next.details !== undefined) {
+      const trimmed = trimUnknownDeep(next.details, settings, "toolResult.details");
+      if (trimmed.changed) {
+        changed = true;
+        next.details = trimmed.value;
+      }
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    api.logger.info?.(
+      `transcript-size-guard: truncated persisted toolResult for tool=${String(event.toolName ?? "unknown")}`,
+    );
+    return { message: next };
+  });
+}
+

--- a/instances/core-human/config/extensions/transcript-size-guard/openclaw.plugin.json
+++ b/instances/core-human/config/extensions/transcript-size-guard/openclaw.plugin.json
@@ -1,0 +1,37 @@
+{
+  "id": "transcript-size-guard",
+  "name": "Transcript Size Guard",
+  "description": "Truncates oversized tool result payloads before they are persisted to session transcripts.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "maxChars": {
+        "type": "number"
+      },
+      "headChars": {
+        "type": "number"
+      },
+      "tailChars": {
+        "type": "number"
+      },
+      "truncateDetails": {
+        "type": "boolean"
+      },
+      "tools": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  },
+  "uiHints": {
+    "maxChars": {
+      "label": "Max Characters",
+      "help": "Maximum length for persisted tool result strings before truncation."
+    },
+    "tools": {
+      "label": "Tool Allowlist",
+      "help": "If set, only these tool names are truncated."
+    }
+  }
+}

--- a/tests/transcript-size-guard.test.ts
+++ b/tests/transcript-size-guard.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import registerPlugin from "../instances/core-human/config/extensions/transcript-size-guard/index";
+
+type HookHandler = (event: Record<string, unknown>) => unknown;
+
+function createHarness(pluginConfig?: Record<string, unknown>) {
+  const hooks: Record<string, HookHandler[]> = {
+    tool_result_persist: [],
+  };
+  const api = {
+    pluginConfig,
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    on: (hookName: string, handler: HookHandler) => {
+      hooks[hookName] ??= [];
+      hooks[hookName].push(handler);
+    },
+  };
+  registerPlugin(api as never);
+  return {
+    toolResultPersist: hooks.tool_result_persist[0],
+  };
+}
+
+describe("transcript-size-guard", () => {
+  test("truncates oversized toolResult text payloads", () => {
+    const { toolResultPersist } = createHarness({
+      maxChars: 100,
+      headChars: 30,
+      tailChars: 20,
+      truncateDetails: false,
+    });
+
+    const longText = "A".repeat(200);
+    const result = toolResultPersist({
+      toolName: "exec",
+      message: {
+        role: "toolResult",
+        content: [{ type: "text", text: longText }],
+      },
+    }) as { message: { content: Array<{ text: string }> } };
+
+    expect(result).toBeDefined();
+    expect(result.message.content[0].text.length).toBeLessThan(longText.length);
+    expect(result.message.content[0].text.includes("truncated")).toBe(true);
+  });
+
+  test("truncates oversized toolResult details when enabled", () => {
+    const { toolResultPersist } = createHarness({
+      maxChars: 120,
+      headChars: 40,
+      tailChars: 30,
+      truncateDetails: true,
+    });
+
+    const longDetails = "Z".repeat(400);
+    const result = toolResultPersist({
+      toolName: "exec",
+      message: {
+        role: "toolResult",
+        content: [{ type: "text", text: "ok" }],
+        details: {
+          aggregated: longDetails,
+        },
+      },
+    }) as { message: { details: { aggregated: string } } };
+
+    expect(result).toBeDefined();
+    expect(result.message.details.aggregated.length).toBeLessThan(longDetails.length);
+    expect(result.message.details.aggregated.includes("truncated")).toBe(true);
+  });
+
+  test("respects configured tool allowlist", () => {
+    const { toolResultPersist } = createHarness({
+      maxChars: 80,
+      headChars: 20,
+      tailChars: 20,
+      tools: ["web_search"],
+    });
+
+    const result = toolResultPersist({
+      toolName: "exec",
+      message: {
+        role: "toolResult",
+        content: [{ type: "text", text: "B".repeat(300) }],
+      },
+    });
+
+    expect(result).toBe(undefined);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add transcript-size-guard plugin to truncate oversized persisted tool results/details
- expand telegram-group-allowlist-guard with DM awareness context for known groups and latest observed snippets
- improve preview extraction to handle structured Telegram content payloads
- keep fail-closed behavior so group replies/tools are blocked for non-allowlist triggers
- update plugin schema metadata for awareness-related config options

## Testing
- bun test tests/telegram-group-allowlist-guard.test.ts tests/transcript-size-guard.test.ts